### PR TITLE
Reinstate memgetinfo utility

### DIFF
--- a/src/trans/gpu/algor/c_hipmemgetinfo.cpp
+++ b/src/trans/gpu/algor/c_hipmemgetinfo.cpp
@@ -1,0 +1,23 @@
+#include "hicblas.h"
+
+
+extern "C" {
+hipError_t c_hipmemgetinfo( int *meg_free, int *meg_total)
+{
+
+  size_t l_free  = 0;
+  size_t l_total = 0;
+
+  hipError_t error_memgetinfo;
+  error_memgetinfo = hipMemGetInfo(&l_free, &l_total);
+
+  long long ll_free = (long long) l_free;
+  long long ll_total = (long long) l_total;
+
+  *meg_free  = (int) (ll_free  / 1048576);
+  *meg_total = (int) (ll_total / 1048576);
+
+  return error_memgetinfo;
+}
+
+}


### PR DESCRIPTION
In order to use this from fortran, add the following to callsite routine,
in the appropriate places
*      use device_mod, only : devicegetmeminfo
*      use iso_c_binding, only : c_int
*      integer(c_int) :: imemfree,imemtotal
*      devicegetmeminfo(imemfree,imemtotal)
*      write(nout,*) 'Current free memory: ',imemfree,' out of total ',imemtotal